### PR TITLE
Replace deprecated ember-cli/lib/ext/promise with rsvp

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 'use strict';
 
 var PluginBase = require('ember-cli-deploy-plugin');
-var Promise = require('ember-cli/lib/ext/promise');
+var RSVP = require('RSVP');
 var readFileSync = require('fs').readFileSync;
 var joinPath = require('path').join;
 
@@ -45,11 +45,11 @@ module.exports = {
 
       configure: function(context) {
         if (!validEnvironment(context.deployTarget)) {
-          return Promise.reject(INVALID_ENVIRONMENT);
+          return RSVP.reject(INVALID_ENVIRONMENT);
         }
 
         if (!this.pluginConfig.key) {
-          return Promise.reject(MISSING_KEY);
+          return RSVP.reject(MISSING_KEY);
         }
 
         this._super.configure.call(this, context);
@@ -111,7 +111,7 @@ module.exports = {
           return uploadAsset(distDir, asset, gzippedFiles && gzippedFiles.indexOf(asset.name) > -1);
         });
 
-        return Promise.all(uploads);
+        return RSVP.all(uploads);
       },
 
       _didUploadAssets: function(assets) {

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,5 +1,5 @@
 var CoreObject = require('core-object');
-var Promise = require('ember-cli/lib/ext/promise');
+var RSVP = require('rsvp');
 var request = require('request');
 
 var HOST = 'https://api.pagefronthq.com';
@@ -63,7 +63,7 @@ module.exports = CoreObject.extend({
       }
     }
 
-    return new Promise(function(resolve, reject) {
+    return new RSVP.Promise(function(resolve, reject) {
       request(options, function (error, response, body) {
         if (error) {
           reject(error);

--- a/lib/upload-asset.js
+++ b/lib/upload-asset.js
@@ -1,8 +1,8 @@
-var Promise = require('ember-cli/lib/ext/promise');
+var RSVP = require('rsvp');
 var mime = require('mime');
 var join = require('path').join;
 var put = require('request').put;
-var readFile = Promise.denodeify(require('fs').readFile);
+var readFile = RSVP.denodeify(require('fs').readFile);
 
 var GZIP = 'gzip';
 var ERROR_THRESHOLD = 400;
@@ -19,7 +19,7 @@ module.exports = function(distDir, asset, gzipped) {
   var cacheDuration = isFingerprinted(asset.name) ? DAY : MINUTE;
 
   return readFile(fullPath).then(function(file) {
-    return new Promise(function(resolve, reject) {
+    return new RSVP.Promise(function(resolve, reject) {
       put({
         url: asset.upload_url,
         body: file,

--- a/package.json
+++ b/package.json
@@ -42,12 +42,13 @@
     "ember-cli-deploy-plugin"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.3",
-    "ember-cli-deploy-plugin": "0.2.0",
     "chalk": "^1.1.0",
     "core-object": "^1.1.0",
+    "ember-cli-babel": "^5.1.3",
+    "ember-cli-deploy-plugin": "0.2.0",
     "mime": "^1.3.4",
-    "request": "^2.58.0"
+    "request": "^2.58.0",
+    "rsvp": "^3.5.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Hi @jasonkriss 

`ember-cli/lib/ext/promise` has been deprecated in ember-cli 2.12 in favor of `rsvp`.
This pr resolves the deprecation warning.